### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/RetsRabbit.php
+++ b/src/RetsRabbit.php
@@ -69,7 +69,7 @@ class RetsRabbit extends Plugin
         self::$plugin = $this;
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new RetsRabbitTwigExtension());
+        Craft::$app->view->registerTwigExtension(new RetsRabbitTwigExtension());
 
         // Register our variables
         Event::on(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.